### PR TITLE
chore(github): 🍱  Add Pull Request Template for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+# Description
+
+<!-- Please include a summary of the changes and the related issue. Also please include relevant motivation and context. List any dependencies that are required
+for this change. -->
+
+<!-- Remove the Below line if it doesn't related to Issues -->
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to
+      not work as expected)
+- [ ] This change requires a documentation update
+
+## How has this been tested?
+
+Please describe the tests that you ran to verify your changes. Provide
+instructions so we can reproduce.
+
+- [ ] Linting Passed
+- [ ] Others
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
- This PR adds a Pull Request Template which will be used when creating a new PR.
- It helps with understanding the motivation of PR and getting feedback about tests from the PR author.